### PR TITLE
Created a virtual filter that is simply a proxy for a custom filter

### DIFF
--- a/include/soloud_c.h
+++ b/include/soloud_c.h
@@ -108,8 +108,12 @@ typedef void * DCRemovalFilter;
 typedef void * Openmpt;
 typedef void * Monotone;
 typedef void * TedSid;
+typedef void * VirtualFilter;
+typedef void * VirtualFilterInstance;
 typedef void * File;
 
+typedef double time;
+  
 /*
  * Soloud
  */
@@ -482,6 +486,16 @@ void TedSid_set3dAttenuator(TedSid * aTedSid, AudioAttenuator * aAttenuator);
 void TedSid_setInaudibleBehavior(TedSid * aTedSid, int aMustTick, int aKill);
 void TedSid_setFilter(TedSid * aTedSid, unsigned int aFilterId, Filter * aFilter);
 void TedSid_stop(TedSid * aTedSid);
+
+/* 
+ * VirtualFilter
+ */
+unsigned int VirtualFilter_count();
+unsigned int VirtualFilter_create(int aNumParams,
+                                  void (*aConstructor)(), void (*aDestructor)(),
+                                  void (*aFilter)(float *, unsigned int, unsigned int, float, time),
+                                  void (*aFilterChannel)(float *,  unsigned int,  float, time));
+VirtualFilterInstance *VirtualFilter_get(int id);
 #ifdef  __cplusplus
 } // extern "C"
 #endif

--- a/include/soloud_virtualfilter.h
+++ b/include/soloud_virtualfilter.h
@@ -1,0 +1,81 @@
+/*
+  SoLoud audio engine
+  Copyright (c) 2013-2015 Jari Komppa
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+  claim that you wrote the original software. If you use this software
+  in a product, an acknowledgment in the product documentation would be
+  appreciated but is not required.
+
+  2. Altered source versions must be plainly marked as such, and must not be
+  misrepresented as being the original software.
+
+  3. This notice may not be removed or altered from any source
+  distribution.
+*/
+/*
+  This file is for an altered version of SoLoud that allows subclassing
+  SoLoud::AudioSource, SoLoud::Filter, SoLoud::AudioCollider, and
+  SoLoud::AudioAttenuator through the C API.
+*/
+
+#ifndef SOLOUD_VIRTUALFILTER_H
+#define SOLOUD_VIRTUALFILTER_H
+
+#include "soloud.h"
+
+namespace SoLoud
+{
+  class VirtualFilter;
+
+  // Maximum number of virtual filters
+  const unsigned int MAXIMUM_VIRTUAL_FILTERS = 128;
+  
+  class VirtualFilterInstance : public FilterInstance
+  {
+    VirtualFilter *mParent;
+    unsigned int mId;
+
+    void (*mDestructor)();
+    void (*mFilter)(float *, unsigned int, unsigned int, float, time);
+    void (*mFilterChannel)(float *,  unsigned int,  float, time, unsigned int, unsigned int);
+
+  public:
+    virtual ~VirtualFilterInstance();
+    virtual void filter(float *aBuffer, unsigned int aSamples, unsigned int aChannels, float aSamplerate, time aTime);
+    virtual void filterChannel(float *aBuffer, unsigned int aSamples, float aSamplerate, time aTime, unsigned int aChannel, unsigned int aChannels);
+    
+    VirtualFilterInstance(VirtualFilter *aParent, unsigned int aId, int aNumParams,
+                          void (*aConstructor)(), void (*aDestructor)(),
+                          void (*aFilter)(float *, unsigned int, unsigned int, float, time),
+                          void (*aFilterChannel)(float *,  unsigned int,  float, time, unsigned int, unsigned int));
+    unsigned int getId();
+  };
+
+  class VirtualFilter : public Filter
+  {
+    unsigned int mId;
+    int mNumParams;
+    void (*mConstructor)();
+    void (*mDestructor)();
+    void (*mFilter)(float *, unsigned int, unsigned int, float, time);
+    void (*mFilterChannel)(float *,  unsigned int,  float, time, unsigned int, unsigned int);
+
+  public:
+    virtual FilterInstance *createInstance();
+    VirtualFilter(unsigned int aId, int aNumParams,
+                  void (*aConstructor)(), void (*aDestructor)(),
+                  void (*aFilter)(float *, unsigned int, unsigned int, float, time),
+                  void (*aFilterChannel)(float *,  unsigned int,  float, time, unsigned int, unsigned int));
+  };
+}
+
+#endif // SOLOUD_VIRTUALFILTER_H

--- a/src/c_api/soloud.def
+++ b/src/c_api/soloud.def
@@ -300,3 +300,6 @@ EXPORTS
 	TedSid_setInaudibleBehavior
 	TedSid_setFilter
 	TedSid_stop
+        VirtualFilter_count
+        VirtualFilter_create
+        VirtualFilter_get

--- a/src/filter/soloud_virtualfilter.cpp
+++ b/src/filter/soloud_virtualfilter.cpp
@@ -1,0 +1,107 @@
+/*
+  SoLoud audio engine
+  Copyright (c) 2013-2015 Jari Komppa
+
+  This software is provided 'as-is', without any express or implied
+  warranty. In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+  claim that you wrote the original software. If you use this software
+  in a product, an acknowledgment in the product documentation would be
+  appreciated but is not required.
+
+  2. Altered source versions must be plainly marked as such, and must not be
+  misrepresented as being the original software.
+
+  3. This notice may not be removed or altered from any source
+  distribution.
+*/
+/*
+  This file is for an altered version of SoLoud that allows subclassing
+  SoLoud::AudioSource, SoLoud::Filter, SoLoud::AudioCollider, and
+  SoLoud::AudioAttenuator through the C API.
+*/
+
+#include "soloud.h"
+#include "soloud_virtualfilter.h"
+
+namespace SoLoud
+{
+  VirtualFilterInstance::VirtualFilterInstance(VirtualFilter *aParent, unsigned int aId, int aNumParams,
+                                               void (*aConstructor)(), void (*aDestructor)(),
+                                               void (*aFilter)(float *, unsigned int, unsigned int, float, time),
+                                               void (*aFilterChannel)(float *,  unsigned int,  float, time, unsigned int, unsigned int))
+  {
+    mId = aId;
+    mParent = aParent;
+
+    mDestructor = aDestructor;
+    mFilter = aFilter;
+    mFilterChannel = aFilterChannel;
+
+    if (aConstructor)
+      aConstructor();
+    
+    initParams(aNumParams);
+  }
+
+  VirtualFilterInstance::~VirtualFilterInstance()
+  {
+    if (mDestructor)
+      mDestructor();
+  }
+
+  unsigned int VirtualFilterInstance::getId()
+  {
+    return mId;
+  }
+
+  void VirtualFilterInstance::filter(float *aBuffer, unsigned int aSamples,
+                                     unsigned int aChannels, float aSamplerate,
+                                     time aTime)
+  {
+    if (mFilter)
+    {
+      updateParams(aTime);
+      mFilter(aBuffer, aSamples, aChannels, aSamplerate, aTime);
+    }
+  }
+
+  void VirtualFilterInstance::filterChannel(float *aBuffer,
+                                            unsigned int aSamples,
+                                            float aSamplerate, time aTime,
+                                            unsigned int aChannel,
+                                            unsigned int aChannels)
+  {
+    if (mFilterChannel)
+    {
+      updateParams(aTime);
+      mFilterChannel(aBuffer, aSamples, aSamplerate, aTime, aChannel, aChannels);
+    }
+  }
+
+  
+  VirtualFilter::VirtualFilter(unsigned int aId, int aNumParams,
+                               void (*aConstructor)(), void (*aDestructor)(),
+                               void (*aFilter)(float *, unsigned int, unsigned int, float, time),
+                               void (*aFilterChannel)(float *,  unsigned int,  float, time, unsigned int, unsigned int))
+  {
+    mId = aId;
+    mNumParams = aNumParams;
+
+    mConstructor = aConstructor;
+    mDestructor = aDestructor;
+    mFilter = aFilter;
+    mFilterChannel = aFilterChannel;
+  }
+
+  FilterInstance *VirtualFilter::createInstance()
+  {
+    return new VirtualFilterInstance(this, mId, mNumParams, mConstructor, mDestructor, mFilter, mFilterChannel);
+  }
+}


### PR DESCRIPTION
As described in the [C API for Subclassing](https://github.com/Shirakumo/soloud/issues/3), there needs to be a way in the C API to subclass filters.

This creates a memory storage of virtual filters in the C API. The virtual filters take functions as parameters and simply proxy to those when necessary.